### PR TITLE
fix: broken website links (DEV-1100)

### DIFF
--- a/services/metadata/backend/data/Rome.json
+++ b/services/metadata/backend/data/Rome.json
@@ -50,7 +50,7 @@
                 "__type": "URL",
                 "type": "URL",
                 "url": "http://vocab.getty.edu/page/tgn/7000874",
-                "text": "http://vocab.getty.edu/page/tgn/7000874"
+                "text": "Rome (inhabited place)"
             }
         ],
         "startDate": "2020-09-01",

--- a/services/metadata/backend/data/Rome.json
+++ b/services/metadata/backend/data/Rome.json
@@ -1,0 +1,413 @@
+{
+    "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+    "project": {
+        "__id": "http://ns.dasch.swiss/repository#dsp-REMA-project",
+        "__type": "Project",
+        "__createdAt": "1657709544615698000",
+        "__createdBy": "dsp-metadata-gui",
+        "howToCite": "Croci, C., Quadri, I, Gianandrea, M., Romano, S., Tosti, E., Chiaraella, M., Ventura, D., Rivoal, M., 2022, Rome in the Early Middle Ages: Arts and Culture [database] (DaSCH), http://ark.dasch.swiss/ark:/72163/1/0118",
+        "teaserText": "The project addresses the visual culture of the city of Rome (Vth-XIth ct.) by means of an interdisciplinary approach (art history, architecture, archaeology archaeometry, liturgy, epigraphy).",
+        "datasets": [
+            "http://ns.dasch.swiss/repository#dsp-REMA-dataset-000"
+        ],
+        "alternativeNames": [
+            {
+                "fr": "rome-siecles-obscurs"
+            }
+        ],
+        "contactPoint": "http://ns.dasch.swiss/repository#dsp-REMA-person-000",
+        "dataManagementPlan": {
+            "__type": "DataManagementPlan",
+            "available": true
+        },
+        "description": {
+            "en": "The ontology of the database comprises three main classes, making it possible to describe paintings and mosaics in the buildings where they are found. The class “Oggetto” (i.e.: mosaic, painting) falls under the class “Cappella” and/or the class “Edificio”. Each of these three classes contains properties (custom controlled vocabularies and text fields), making it possible to characterize the building, chapel, paintings or mosaic using names, location, description, state of preservation, analysis, dating, patrons, inscriptions, sources, critical commentary, bibliography. Illustrations can be added to the three main categories using two further classes, ‘Illustrazioni’ and ‘Illustrazioni ad accesso limitato’, whose properties (also text fields and controlled vocabularies) include information on the type of image and photograph credits."
+        },
+        "disciplines": [
+            {
+                "en": "10402 Archaeology"
+            },
+            {
+                "en": "10404 Visual arts and Art history"
+            }
+        ],
+        "endDate": "2023-08-31",
+        "funders": [
+            "http://ns.dasch.swiss/repository#dsp-REMA-organization-001"
+        ],
+        "grants": [
+            "http://ns.dasch.swiss/repository#dsp-REMA-grant-000"
+        ],
+        "keywords": [
+            {
+                "en": "painting; mosaic; visual culture; iconography; style; archaeometry; epigraphy; archaeology; historiography; papacy; Rome; artistic geography; early Middle Ages; Goths; Byzantines; Carolingians; Ottonians"
+            }
+        ],
+        "name": "Rome in the Early Middle Ages: Arts and Culture",
+        "shortcode": "0118",
+        "spatialCoverage": [
+            {
+                "__type": "URL",
+                "type": "URL",
+                "url": "http://vocab.getty.edu/page/tgn/7000874",
+                "text": "http://vocab.getty.edu/page/tgn/7000874"
+            }
+        ],
+        "startDate": "2020-09-01",
+        "temporalCoverage": [
+            {
+                "__type": "URL",
+                "type": "Chronontology",
+                "url": "https://chronontology.dainst.org/period/ZkwNN4oimUDM",
+                "text": "Middle Ages, 500-1500"
+            }
+        ]
+    },
+    "datasets": [
+        {
+            "__id": "http://ns.dasch.swiss/repository#dsp-REMA-dataset-000",
+            "__type": "Dataset",
+            "__createdAt": "1657709546374431000",
+            "__createdBy": "dsp-metadata-gui",
+            "abstracts": [
+                {
+                    "en": "The project addresses the visual culture of the city of Rome (Vth-XIth ct.) by means of an interdisciplinary approach (art history, architecture, archaeology archaeometry, liturgy, epigraphy)."
+                }
+            ],
+            "alternativeTitles": [
+                {
+                    "fr": "rome-siecles-obscurs"
+                }
+            ],
+            "accessConditions": "restricted",
+            "howToCite": "Croci, C., Quadri, I, Gianandrea, M., Romano, S., Tosti, E., Chiaraella, M., Ventura, D., Rivoal, M., 2022, Rome in the Early Middle Ages: Arts and Culture [database] (DaSCH), http://ark.dasch.swiss/ark:/72163/1/0118",
+            "languages": [
+                {
+                    "en": "Italian",
+                    "de": "Italienisch",
+                    "fr": "italien"
+                }
+            ],
+            "licenses": [
+                {
+                    "__type": "License",
+                    "date": "2022-07-13",
+                    "license": {
+                        "__type": "URL",
+                        "type": "Creative Commons",
+                        "url": "https://creativecommons.org/licenses/by-sa/4.0/",
+                        "text": "CC BY-SA 4.0"
+                    }
+                }
+            ],
+            "attributions": [
+                {
+                    "__type": "Attribution",
+                    "agent": "http://ns.dasch.swiss/repository#dsp-REMA-person-000",
+                    "roles": [
+                        "Project Leader"
+                    ]
+                },
+                {
+                    "__type": "Attribution",
+                    "agent": "http://ns.dasch.swiss/repository#dsp-REMA-person-004",
+                    "roles": [
+                        "Data Collector"
+                    ]
+                },
+                {
+                    "__type": "Attribution",
+                    "agent": "http://ns.dasch.swiss/repository#dsp-REMA-person-002",
+                    "roles": [
+                        "Data Curator"
+                    ]
+                },
+                {
+                    "__type": "Attribution",
+                    "agent": "http://ns.dasch.swiss/repository#dsp-REMA-person-007",
+                    "roles": [
+                        "Data Collector"
+                    ]
+                },
+                {
+                    "__type": "Attribution",
+                    "agent": "http://ns.dasch.swiss/repository#dsp-REMA-person-003",
+                    "roles": [
+                        "Data Collector"
+                    ]
+                },
+                {
+                    "__type": "Attribution",
+                    "agent": "http://ns.dasch.swiss/repository#dsp-REMA-person-006",
+                    "roles": [
+                        "Project Member"
+                    ]
+                },
+                {
+                    "__type": "Attribution",
+                    "agent": "http://ns.dasch.swiss/repository#dsp-REMA-person-005",
+                    "roles": [
+                        "Researcher"
+                    ]
+                },
+                {
+                    "__type": "Attribution",
+                    "agent": "http://ns.dasch.swiss/repository#dsp-REMA-person-001",
+                    "roles": [
+                        "Project Leader"
+                    ]
+                }
+            ],
+            "status": "Ongoing",
+            "title": "Database of the project Rome in the Early Middle Ages: Arts and Culture",
+            "typeOfData": [
+                "Image",
+                "Text"
+            ],
+            "urls": [
+                {
+                    "__type": "URL",
+                    "type": "URL",
+                    "url": "http://ark.dasch.swiss/ark:/72163/1/0118",
+                    "text": "http://ark.dasch.swiss/ark:/72163/1/0118"
+                }
+            ]
+        }
+    ],
+    "persons": [
+        {
+            "__id": "http://ns.dasch.swiss/repository#dsp-REMA-person-001",
+            "__type": "Person",
+            "__createdAt": "1657709547134209000",
+            "__createdBy": "dsp-metadata-gui",
+            "email": "Irene.Quadri@unil.ch",
+            "familyNames": [
+                "Quadri"
+            ],
+            "givenNames": [
+                "Irene"
+            ],
+            "jobTitles": [
+                "Data Collector",
+                "Project Leader"
+            ],
+            "affiliation": [
+                "http://ns.dasch.swiss/repository#dsp-REMA-organization-000"
+            ]
+        },
+        {
+            "__id": "http://ns.dasch.swiss/repository#dsp-REMA-person-002",
+            "__type": "Person",
+            "__createdAt": "1657709547134310000",
+            "__createdBy": "dsp-metadata-gui",
+            "email": "Marion.Rivoal@unil.ch",
+            "familyNames": [
+                "Rivoal"
+            ],
+            "givenNames": [
+                "Marion"
+            ],
+            "jobTitles": [
+                "Data Curator"
+            ],
+            "affiliation": [
+                "http://ns.dasch.swiss/repository#dsp-REMA-organization-000"
+            ]
+        },
+        {
+            "__id": "http://ns.dasch.swiss/repository#dsp-REMA-person-003",
+            "__type": "Person",
+            "__createdAt": "1657709547134410000",
+            "__createdBy": "dsp-metadata-gui",
+            "email": "mariaelena.chiarella@unil.ch",
+            "familyNames": [
+                "Chiarella"
+            ],
+            "givenNames": [
+                "Maria Elena"
+            ],
+            "jobTitles": [
+                "Data Collector",
+                "Project Member"
+            ],
+            "affiliation": [
+                "http://ns.dasch.swiss/repository#dsp-REMA-organization-000"
+            ]
+        },
+        {
+            "__id": "http://ns.dasch.swiss/repository#dsp-REMA-person-004",
+            "__type": "Person",
+            "__createdAt": "1657709547134507000",
+            "__createdBy": "dsp-metadata-gui",
+            "email": "Eleonora.tosti@unil.ch",
+            "familyNames": [
+                "Tosti"
+            ],
+            "givenNames": [
+                "Eleonora"
+            ],
+            "jobTitles": [
+                "Data Collector",
+                "Project Member"
+            ],
+            "affiliation": [
+                "http://ns.dasch.swiss/repository#dsp-REMA-organization-000"
+            ]
+        },
+        {
+            "__id": "http://ns.dasch.swiss/repository#dsp-REMA-person-005",
+            "__type": "Person",
+            "__createdAt": "1657709547134588000",
+            "__createdBy": "dsp-metadata-gui",
+            "email": "Serena.Romano@unil.ch",
+            "familyNames": [
+                "Romano"
+            ],
+            "givenNames": [
+                "Serena"
+            ],
+            "jobTitles": [
+                "Project Member",
+                "Researcher"
+            ],
+            "affiliation": [
+                "http://ns.dasch.swiss/repository#dsp-REMA-organization-000"
+            ]
+        },
+        {
+            "__id": "http://ns.dasch.swiss/repository#dsp-REMA-person-006",
+            "__type": "Person",
+            "__createdAt": "1657709547134672000",
+            "__createdBy": "dsp-metadata-gui",
+            "email": "Manuela.Gianandrea@unil.ch",
+            "familyNames": [
+                "Gianandrea"
+            ],
+            "givenNames": [
+                "Manuela"
+            ],
+            "jobTitles": [
+                "Project Member"
+            ],
+            "affiliation": [
+                "http://ns.dasch.swiss/repository#dsp-REMA-organization-000",
+                "http://ns.dasch.swiss/repository#dsp-REMA-organization-002"
+            ]
+        },
+        {
+            "__id": "http://ns.dasch.swiss/repository#dsp-REMA-person-007",
+            "__type": "Person",
+            "__createdAt": "1657709547134778000",
+            "__createdBy": "dsp-metadata-gui",
+            "email": "mimmoventura74@gmail.com",
+            "familyNames": [
+                "Ventura"
+            ],
+            "givenNames": [
+                "Domenico"
+            ],
+            "jobTitles": [
+                "Data Collector"
+            ],
+            "affiliation": [
+                "http://ns.dasch.swiss/repository#dsp-REMA-organization-000"
+            ]
+        },
+        {
+            "__id": "http://ns.dasch.swiss/repository#dsp-REMA-person-000",
+            "__type": "Person",
+            "__createdAt": "1657709547134887000",
+            "__createdBy": "dsp-metadata-gui",
+            "email": "Chiara.Croci@unil.ch",
+            "familyNames": [
+                "Chiara"
+            ],
+            "givenNames": [
+                "Croci"
+            ],
+            "jobTitles": [
+                "Data Collector",
+                "Project Leader"
+            ],
+            "affiliation": [
+                "http://ns.dasch.swiss/repository#dsp-REMA-organization-000"
+            ]
+        }
+    ],
+    "organizations": [
+        {
+            "__id": "http://ns.dasch.swiss/repository#dsp-REMA-organization-002",
+            "__type": "Organization",
+            "__createdAt": "1657709547135008000",
+            "__createdBy": "dsp-metadata-gui",
+            "address": {
+                "__type": "Address",
+                "street": "",
+                "postalCode": "",
+                "locality": "Sapienza",
+                "country": "Italy"
+            },
+            "name": "University of Rome"
+        },
+        {
+            "__id": "http://ns.dasch.swiss/repository#dsp-REMA-organization-001",
+            "__type": "Organization",
+            "__createdAt": "1657709547222387000",
+            "__createdBy": "dsp-metadata-gui",
+            "address": {
+                "__type": "Address",
+                "street": "Wildhainweg 3 Postfach",
+                "postalCode": "3001",
+                "locality": "Bern",
+                "country": "Switzerland"
+            },
+            "email": "desk@snf.ch",
+            "name": "Swiss National Science Foundation (SNSF)",
+            "url": {
+                "__type": "URL",
+                "type": "URL",
+                "url": "http://www.snf.ch/",
+                "text": "http://www.snf.ch/"
+            }
+        },
+        {
+            "__id": "http://ns.dasch.swiss/repository#dsp-REMA-organization-000",
+            "__type": "Organization",
+            "__createdAt": "1657709547268009000",
+            "__createdBy": "dsp-metadata-gui",
+            "address": {
+                "__type": "Address",
+                "street": "Unicentre",
+                "postalCode": "1015",
+                "locality": "Lausanne",
+                "country": "Switzerland"
+            },
+            "name": "University of Lausanne",
+            "url": {
+                "__type": "URL",
+                "type": "URL",
+                "url": "http://www.unil.ch",
+                "text": "www.unil.ch"
+            }
+        }
+    ],
+    "grants": [
+        {
+            "__id": "http://ns.dasch.swiss/repository#dsp-REMA-grant-000",
+            "__type": "Grant",
+            "__createdAt": "1657709547313726000",
+            "__createdBy": "dsp-metadata-gui",
+            "funders": [
+                "http://ns.dasch.swiss/repository#dsp-REMA-organization-001"
+            ],
+            "name": "Div. I-III",
+            "number": "192854",
+            "url": {
+                "__type": "URL",
+                "type": "URL",
+                "url": "https://p3.snf.ch/Project-192854",
+                "text": "https://p3.snf.ch/Project-192854"
+            }
+        }
+    ]
+}

--- a/services/metadata/backend/data/awg.json
+++ b/services/metadata/backend/data/awg.json
@@ -650,8 +650,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "http://p3.snf.ch/Project-157968",
-                "text": "http://p3.snf.ch/Project-157968"
+                "url": "https://data.snf.ch/grants/grant/157968",
+                "text": "https://data.snf.ch/grants/grant/157968"
             }
         },
         {
@@ -667,8 +667,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "http://p3.snf.ch/Project-162871",
-                "text": "http://p3.snf.ch/Project-162871"
+                "url": "https://data.snf.ch/grants/grant/162871",
+                "text": "https://data.snf.ch/grants/grant/162871"
             }
         },
         {
@@ -684,8 +684,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "http://p3.snf.ch/Project-143565",
-                "text": "http://p3.snf.ch/Project-143565"
+                "url": "https://data.snf.ch/grants/grant/143565",
+                "text": "https://data.snf.ch/grants/grant/143565"
             }
         },
         {
@@ -701,8 +701,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "http://p3.snf.ch/Project-126789",
-                "text": "http://p3.snf.ch/Project-126789"
+                "url": "https://data.snf.ch/grants/grant/126789",
+                "text": "https://data.snf.ch/grants/grant/126789"
             }
         },
         {
@@ -718,8 +718,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "http://p3.snf.ch/Project-113769",
-                "text": "http://p3.snf.ch/Project-113769"
+                "url": "https://data.snf.ch/grants/grant/113769",
+                "text": "https://data.snf.ch/grants/grant/113769"
             }
         },
         {

--- a/services/metadata/backend/data/beol.json
+++ b/services/metadata/backend/data/beol.json
@@ -127,6 +127,12 @@
         "url": {
             "__type": "URL",
             "type": "URL",
+            "url": "https://admin.dasch.swiss/beta/project/0801",
+            "text": "https://admin.dasch.swiss/beta/project/0801"
+        },
+        "url": {
+            "__type": "URL",
+            "type": "URL",
             "url": "https://beol.dasch.swiss/",
             "text": "https://beol.dasch.swiss/"
         }
@@ -599,8 +605,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "http://p3.snf.ch/project-166072",
-                "text": "http://p3.snf.ch/project-166072"
+                "url": "https://data.snf.ch/grants/grant/166072",
+                "text": "https://data.snf.ch/grants/grant/166072"
             }
         },
         {

--- a/services/metadata/backend/data/beol.json
+++ b/services/metadata/backend/data/beol.json
@@ -130,7 +130,7 @@
             "url": "https://admin.dasch.swiss/beta/project/0801",
             "text": "https://admin.dasch.swiss/beta/project/0801"
         },
-        "url": {
+        "secondaryURL": {
             "__type": "URL",
             "type": "URL",
             "url": "https://beol.dasch.swiss/",

--- a/services/metadata/backend/data/beyondthetext.json
+++ b/services/metadata/backend/data/beyondthetext.json
@@ -380,8 +380,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "https://p3.snf.ch/project-193226",
-                "text": "https://p3.snf.ch/project-193226"
+                "url": "https://data.snf.ch/grants/grant/193226",
+                "text": "https://data.snf.ch/grants/grant/193226"
             }
         }
     ]

--- a/services/metadata/backend/data/big-data-in-agriculture.json
+++ b/services/metadata/backend/data/big-data-in-agriculture.json
@@ -76,6 +76,12 @@
         "url": {
             "__type": "URL",
             "type": "URL",
+            "url": "https://admin.dasch.swiss/beta/project/082D",
+            "text": "https://admin.dasch.swiss/beta/project/082D"
+        },
+        "url": {
+            "__type": "URL",
+            "type": "URL",
             "url": "http://www.unine.ch/geographie/en/home/recherche/--espace-et-pouvoir-a-lere-du-nu/research-projects/smart-farming.html",
             "text": "http://www.unine.ch/geographie/en/home/recherche/--espace-et-pouvoir-a-lere-du-nu/research-projects/smart-farming.html"
         }
@@ -247,12 +253,12 @@
                 "http://ns.dasch.swiss/repository#dsp-082D-organization-001"
             ],
             "name": "Digital Lives",
-            "number": "FN 10DL1A_183037",
+            "number": "183037",
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "http://www.snf.ch/de/foerderung/projekte/digital-lives/Seiten/default.aspx",
-                "text": "http://www.snf.ch/de/foerderung/projekte/digital-lives/Seiten/default.aspx"
+                "url": "https://data.snf.ch/grants/grant/183037",
+                "text": "https://data.snf.ch/grants/grant/183037"
             }
         }
     ]

--- a/services/metadata/backend/data/big-data-in-agriculture.json
+++ b/services/metadata/backend/data/big-data-in-agriculture.json
@@ -79,7 +79,7 @@
             "url": "https://admin.dasch.swiss/beta/project/082D",
             "text": "https://admin.dasch.swiss/beta/project/082D"
         },
-        "url": {
+        "secondaryURL": {
             "__type": "URL",
             "type": "URL",
             "url": "http://www.unine.ch/geographie/en/home/recherche/--espace-et-pouvoir-a-lere-du-nu/research-projects/smart-farming.html",

--- a/services/metadata/backend/data/biz.json
+++ b/services/metadata/backend/data/biz.json
@@ -519,8 +519,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "https://p3.snf.ch/Project-130398",
-                "text": "https://p3.snf.ch/Project-130398"
+                "url": "https://data.snf.ch/grants/grant/130398",
+                "text": "https://data.snf.ch/grants/grant/130398"
             }
         },
         {
@@ -536,8 +536,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "http://p3.snf.ch/Project-146239",
-                "text": "http://p3.snf.ch/Project-146239"
+                "url": "https://data.snf.ch/grants/grant/146239",
+                "text": "https://data.snf.ch/grants/grant/146239"
             }
         },
         {
@@ -553,8 +553,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "https://p3.snf.ch/Project-170407",
-                "text": "https://p3.snf.ch/Project-170407"
+                "url": "https://data.snf.ch/grants/grant/170407",
+                "text": "https://data.snf.ch/grants/grant/170407"
             }
         },
         {
@@ -570,8 +570,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "http://p3.snf.ch/Project-198049",
-                "text": "http://p3.snf.ch/Project-198049"
+                "url": "https://data.snf.ch/grants/grant/198049",
+                "text": "https://data.snf.ch/grants/grant/198049"
             }
         }
     ]

--- a/services/metadata/backend/data/bruno-manser.json
+++ b/services/metadata/backend/data/bruno-manser.json
@@ -86,13 +86,7 @@
                 "en": "1984 - 2000",
                 "fr": "1984 - 2000"
             }
-        ],
-        "url": {
-            "__type": "URL",
-            "type": "URL",
-            "url": "https://data.dasch.swiss/bmf/",
-            "text": "https://data.dasch.swiss/bmf/"
-        }
+        ]
     },
     "datasets": [
         {

--- a/services/metadata/backend/data/cache.json
+++ b/services/metadata/backend/data/cache.json
@@ -76,6 +76,12 @@
         "url": {
             "__type": "URL",
             "type": "URL",
+            "url": "https://admin.dasch.swiss/beta/project/082B",
+            "text": "https://admin.dasch.swiss/beta/project/082B"
+        },
+        "url": {
+            "__type": "URL",
+            "type": "URL",
             "url": "http://www.cache.ch",
             "text": "www.cache.ch"
         }
@@ -493,12 +499,12 @@
                 "http://ns.dasch.swiss/repository#dsp-082B-organization-003"
             ],
             "name": "Digital Lives SNF",
-            "number": "http://p3.snf.ch/Project-183057",
+            "number": "183057",
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "http://p3.snf.ch/Project-183057",
-                "text": "183057"
+                "url": "https://data.snf.ch/grants/grant/183057",
+                "text": "https://data.snf.ch/grants/grant/183057"
             }
         }
     ]

--- a/services/metadata/backend/data/cache.json
+++ b/services/metadata/backend/data/cache.json
@@ -79,7 +79,7 @@
             "url": "https://admin.dasch.swiss/beta/project/082B",
             "text": "https://admin.dasch.swiss/beta/project/082B"
         },
-        "url": {
+        "secondaryURL": {
             "__type": "URL",
             "type": "URL",
             "url": "http://www.cache.ch",

--- a/services/metadata/backend/data/decoso.json
+++ b/services/metadata/backend/data/decoso.json
@@ -276,8 +276,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "https://p3.snf.ch/project-184864",
-                "text": "https://p3.snf.ch/project-184864"
+                "url": "https://data.snf.ch/grants/grant/184864",
+                "text": "https://data.snf.ch/grants/grant/184864"
             }
         }
     ]

--- a/services/metadata/backend/data/delille.json
+++ b/services/metadata/backend/data/delille.json
@@ -5,7 +5,7 @@
         "__type": "Project",
         "__createdAt": "1630601383511170000",
         "__createdBy": "dsp-metadata-gui",
-        "howToCite": "Reconstruire Delille, 2021, https://delille.dasch.swiss",
+        "howToCite": "Reconstruire Delille, 2021",
         "teaserText": "NIE-INE outcome for the project `Reconstruire Delille' in relation to the scholarly `reverse' edition of the reception of the third canto of Jacques Delille's L'homme des champs.",
         "datasets": [
             "http://ns.dasch.swiss/repository#dsp-081B-dataset-001"
@@ -132,14 +132,6 @@
             "title": "Delille",
             "typeOfData": [
                 "XML"
-            ],
-            "urls": [
-                {
-                    "__type": "URL",
-                    "type": "URL",
-                    "url": "https://delille.dasch.swiss/",
-                    "text": "https://delille.dasch.swiss/"
-                }
             ]
         }
     ],
@@ -222,8 +214,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "http://p3.snf.ch/project-153189",
-                "text": "http://p3.snf.ch/project-153189"
+                "url": "https://data.snf.ch/grants/grant/153189",
+                "text": "https://data.snf.ch/grants/grant/153189"
             }
         }
     ]

--- a/services/metadata/backend/data/drawings.json
+++ b/services/metadata/backend/data/drawings.json
@@ -158,8 +158,8 @@
         "url": {
             "__type": "URL",
             "type": "URL",
-            "url": "https://admin.ls-prod-server.dasch.swiss/project/0105/info",
-            "text": "https://admin.ls-prod-server.dasch.swiss/project/0105/info"
+            "url": "https://admin.ls-prod-server.dasch.swiss/beta/project/0105",
+            "text": "https://admin.ls-prod-server.dasch.swiss/beta/project/0105"
         },
         "secondaryURL": {
             "__type": "URL",

--- a/services/metadata/backend/data/drawings.json
+++ b/services/metadata/backend/data/drawings.json
@@ -646,8 +646,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "http://p3.snf.ch/Project-156383",
-                "text": "http://p3.snf.ch/Project-156383"
+                "url": "https://data.snf.ch/grants/grant/156383",
+                "text": "https://data.snf.ch/grants/grant/156383"
             }
         }
     ]

--- a/services/metadata/backend/data/eHKKA.json
+++ b/services/metadata/backend/data/eHKKA.json
@@ -1,0 +1,299 @@
+{
+    "$schema": "https://raw.githubusercontent.com/dasch-swiss/dsp-meta-svc/main/docs/services/metadata/schema-metadata.json",
+    "project": {
+        "__id": "http://ns.dasch.swiss/repository#dsp-083C-project",
+        "__type": "Project",
+        "__createdAt": "1658837460816710000",
+        "__createdBy": "dsp-metadata-gui",
+        "howToCite": "Morgenthaler et al., historisch-kritsche Kellerausgabe online, 1996-2013",
+        "teaserText": "Gottfried Keller (1819-1890) gehört zu den grossen Autoren des Realismus. Die eHKKA ediert Kellers Gesamtwerk: Seine Romane, Novellen, Gedichte, Tagebücher und Briefe.",
+        "datasets": [
+            "http://ns.dasch.swiss/repository#dsp-083C-dataset-000"
+        ],
+        "alternativeNames": [
+            {
+                "de": "HKKA"
+            }
+        ],
+        "contactPoint": "http://ns.dasch.swiss/repository#dsp-083C-person-003",
+        "description": {
+            "de": "Die HKKA war ein Meilenstein der computergestützten Editonsphilologie. Sie dokumentiert nicht nur die Entstehungs- und Publikationsgeschichte der von Keller veröffentlichten Werke, sondern präsentiert erstmals ohne willkürliche Selektion den gesamten literarischen Nachlass. Nach Abschluss der Buchausgabe soll die Ausgabe nun auch in benutzerfreundlicher Art auf dem Netzt zugänglich gemacht werden."
+        },
+        "disciplines": [
+            {
+                "de": "10302 Schweizer Geschichte"
+            },
+            {
+                "de": "10501 Sprach- und Literaturwissenschaft"
+            }
+        ],
+        "endDate": "2013-07-31",
+        "funders": [
+            "http://ns.dasch.swiss/repository#dsp-083C-organization-000"
+        ],
+        "grants": [
+            "http://ns.dasch.swiss/repository#dsp-083C-grant-000"
+        ],
+        "keywords": [
+            {
+                "en": "Arts"
+            },
+            {
+                "en": "German Literature"
+            },
+            {
+                "en": "History"
+            },
+            {
+                "en": "Politics"
+            },
+            {
+                "en": "Swiss Literature"
+            }
+        ],
+        "name": "Historische-Kritische Gottfried Keller Ausgabe (HKKA)",
+        "publications": [
+            "Gottfried Keller: Sämtliche Werke. Historisch-Kritische Ausgabe. Herausgegeben unter der Leitung von Walter Morgenthaler im Auftrag der Stiftung Historisch-Kritische Gottfried Keller-Ausgabe. 32 Bände. Frankfurt a. M., Basel und Zürich 1996-2013."
+        ],
+        "shortcode": "083C",
+        "spatialCoverage": [
+            {
+                "__type": "URL",
+                "type": "Geonames",
+                "url": "https://www.geonames.org/2921044/federal-republic-of-germany.html",
+                "text": "Germany"
+            },
+            {
+                "__type": "URL",
+                "type": "Geonames",
+                "url": "https://www.geonames.org/2658434/switzerland.html",
+                "text": "Switzerland"
+            }
+        ],
+        "startDate": "1991-04-01",
+        "temporalCoverage": [
+            {
+                "__type": "URL",
+                "type": "Chronontology",
+                "url": "http://chronontology.dainst.org/period/5C8DINGE1IXb",
+                "text": "19th Century"
+            }
+        ],
+        "url": {
+            "__type": "URL",
+            "type": "URL",
+            "url": "https://www.ehkka.ch/ehkka/",
+            "text": "https://www.ehkka.ch/ehkka/"
+        }
+    },
+    "datasets": [
+        {
+            "__id": "http://ns.dasch.swiss/repository#dsp-083C-dataset-000",
+            "__type": "Dataset",
+            "__createdAt": "1658837462051680000",
+            "__createdBy": "dsp-metadata-gui",
+            "abstracts": [
+                {
+                    "de": "Eine online-Edition der Historisch-Kritischen Kellerausgabe"
+                }
+            ],
+            "alternativeTitles": [
+                {
+                    "de": "eHKKA"
+                }
+            ],
+            "accessConditions": "open",
+            "datePublished": "1996-01-01",
+            "howToCite": "Morgenthaler et al., historisch-kritsche Kellerausgabe online, 1996-2013.",
+            "languages": [
+                {
+                    "de": "Deutsch"
+                }
+            ],
+            "attributions": [
+                {
+                    "__type": "Attribution",
+                    "agent": "http://ns.dasch.swiss/repository#dsp-083C-person-002",
+                    "roles": [
+                        "2000-2013 vollberuflicher Mitarbeiter der HKKA 2000-2013 Mitglied des Herausgeberteams, zuständig für EDV  "
+                    ]
+                },
+                {
+                    "__type": "Attribution",
+                    "agent": "http://ns.dasch.swiss/repository#dsp-083C-person-000",
+                    "roles": [
+                        "1991-2012: Vollberuflicher Mitarbeiter der HKKA  Initiant des Projekts und Leiter des Herausgeberteams"
+                    ]
+                },
+                {
+                    "__type": "Attribution",
+                    "agent": "http://ns.dasch.swiss/repository#dsp-083C-organization-000",
+                    "roles": [
+                        "Creator of Dataset"
+                    ]
+                }
+            ],
+            "status": "Finished",
+            "title": "Historisch-Kritische Kellerausgabe online",
+            "typeOfData": [
+                "Image",
+                "Text",
+                "XML"
+            ]
+        }
+    ],
+    "persons": [
+        {
+            "__id": "http://ns.dasch.swiss/repository#dsp-083C-person-001",
+            "__type": "Person",
+            "__createdAt": "1658837462207965000",
+            "__createdBy": "dsp-metadata-gui",
+            "familyNames": [
+                "Amrein"
+            ],
+            "givenNames": [
+                "Ursula"
+            ],
+            "jobTitles": [
+                "Mitglied des Stiftungsrates HKKA"
+            ],
+            "affiliation": [
+                "http://ns.dasch.swiss/repository#dsp-083C-organization-000",
+                "http://ns.dasch.swiss/repository#dsp-083C-organization-005"
+            ]
+        },
+        {
+            "__id": "http://ns.dasch.swiss/repository#dsp-083C-person-000",
+            "__type": "Person",
+            "__createdAt": "1658837462208018000",
+            "__createdBy": "dsp-metadata-gui",
+            "familyNames": [
+                "Morgenthaler"
+            ],
+            "givenNames": [
+                "Walter"
+            ],
+            "jobTitles": [
+                "1991-2012: Vollberuflicher Mitarbeiter der HKKA  Initiant des Projekts und Leiter des Herausgeberteams"
+            ],
+            "affiliation": [
+                "http://ns.dasch.swiss/repository#dsp-083C-organization-000",
+                "http://ns.dasch.swiss/repository#dsp-083C-organization-005"
+            ]
+        },
+        {
+            "__id": "http://ns.dasch.swiss/repository#dsp-083C-person-002",
+            "__type": "Person",
+            "__createdAt": "1658837462208065000",
+            "__createdBy": "dsp-metadata-gui",
+            "familyNames": [
+                "Grob"
+            ],
+            "givenNames": [
+                "Karl"
+            ],
+            "jobTitles": [
+                "2000-2013 vollberuflicher Mitarbeiter der HKKA 2000-2013 Mitglied des Herausgeberteams, zuständig für EDV"
+            ],
+            "affiliation": [
+                "http://ns.dasch.swiss/repository#dsp-083C-organization-000"
+            ]
+        },
+        {
+            "__id": "http://ns.dasch.swiss/repository#dsp-083C-person-003",
+            "__type": "Person",
+            "__createdAt": "1658837462208103000",
+            "__createdBy": "dsp-metadata-gui",
+            "email": "dom.muller@bluewin.ch",
+            "familyNames": [
+                "Müller"
+            ],
+            "givenNames": [
+                "Dominik"
+            ],
+            "jobTitles": [
+                "Bis 2018: Maître d’enseignement et de recherche, Départemet de langue et de littérature allemandes, Faculté des Lettres, Université de Genève 1991-2013 Beratendes Mitglied des Herausgeberteams; seit 2016 Präsident der Stiftung für eine Historisch-Kritische Gottfried Keller-Ausgabe"
+            ],
+            "affiliation": [
+                "http://ns.dasch.swiss/repository#dsp-083C-organization-000",
+                "http://ns.dasch.swiss/repository#dsp-083C-organization-006"
+            ]
+        }
+    ],
+    "organizations": [
+        {
+            "__id": "http://ns.dasch.swiss/repository#dsp-083C-organization-001",
+            "__type": "Organization",
+            "__createdAt": "1658837462208169000",
+            "__createdBy": "dsp-metadata-gui",
+            "address": {
+                "__type": "Address",
+                "street": "Wildhainweg 3, Postfach",
+                "postalCode": "3001",
+                "locality": "Bern",
+                "country": "Switzerland"
+            },
+            "name": "Schweizerischer Nationalfonds"
+        },
+        {
+            "__id": "http://ns.dasch.swiss/repository#dsp-083C-organization-006",
+            "__type": "Organization",
+            "__createdAt": "1658837462261695000",
+            "__createdBy": "dsp-metadata-gui",
+            "address": {
+                "__type": "Address",
+                "street": "24 rue du Général-Dufour",
+                "postalCode": "1211",
+                "locality": "Genève 4",
+                "country": "Switzerland"
+            },
+            "name": "Université de Genève, Départemet de langue et de littérature allemandes, Faculté des Lettres"
+        },
+        {
+            "__id": "http://ns.dasch.swiss/repository#dsp-083C-organization-005",
+            "__type": "Organization",
+            "__createdAt": "1658837462308236000",
+            "__createdBy": "dsp-metadata-gui",
+            "address": {
+                "__type": "Address",
+                "street": "Schönberggasse 9",
+                "postalCode": "8001",
+                "locality": "Zürich",
+                "country": "Switzerland"
+            },
+            "name": "Deutsches Seminar, Universität Zürich"
+        },
+        {
+            "__id": "http://ns.dasch.swiss/repository#dsp-083C-organization-000",
+            "__type": "Organization",
+            "__createdAt": "1658837462388956000",
+            "__createdBy": "dsp-metadata-gui",
+            "address": {
+                "__type": "Address",
+                "street": "c/o Pestalozzi Rechtsanwälte, Löwenstrasse 1",
+                "postalCode": "8000",
+                "locality": "Zürich",
+                "country": "Switzerland"
+            },
+            "email": "dom.muller@bluewin.ch",
+            "name": "Stiftung für eine Historisch-Kritische Gottfried Keller-Ausgabe"
+        }
+    ],
+    "grants": [
+        {
+            "__id": "http://ns.dasch.swiss/repository#dsp-083C-grant-000",
+            "__type": "Grant",
+            "__createdAt": "1658837462427587000",
+            "__createdBy": "dsp-metadata-gui",
+            "funders": [
+                "http://ns.dasch.swiss/repository#dsp-083C-organization-001"
+            ],
+            "url": {
+                "__type": "URL",
+                "type": "URL",
+                "url": "https://www.snf.ch/de",
+                "text": "https://www.snf.ch/de"
+            }
+        }
+    ]
+}

--- a/services/metadata/backend/data/eHKKA.json
+++ b/services/metadata/backend/data/eHKKA.json
@@ -124,13 +124,6 @@
                     "roles": [
                         "1991-2012: Vollberuflicher Mitarbeiter der HKKA  Initiant des Projekts und Leiter des Herausgeberteams"
                     ]
-                },
-                {
-                    "__type": "Attribution",
-                    "agent": "http://ns.dasch.swiss/repository#dsp-083C-organization-000",
-                    "roles": [
-                        "Creator of Dataset"
-                    ]
                 }
             ],
             "status": "Finished",
@@ -155,7 +148,7 @@
                 "Ursula"
             ],
             "jobTitles": [
-                "Mitglied des Stiftungsrates HKKA"
+                "Prof. Dr. phil."
             ],
             "affiliation": [
                 "http://ns.dasch.swiss/repository#dsp-083C-organization-000",
@@ -174,7 +167,7 @@
                 "Walter"
             ],
             "jobTitles": [
-                "1991-2012: Vollberuflicher Mitarbeiter der HKKA  Initiant des Projekts und Leiter des Herausgeberteams"
+                "Dr. phil."
             ],
             "affiliation": [
                 "http://ns.dasch.swiss/repository#dsp-083C-organization-000",
@@ -193,7 +186,7 @@
                 "Karl"
             ],
             "jobTitles": [
-                "2000-2013 vollberuflicher Mitarbeiter der HKKA 2000-2013 Mitglied des Herausgeberteams, zuständig für EDV"
+                "Dr. phil."
             ],
             "affiliation": [
                 "http://ns.dasch.swiss/repository#dsp-083C-organization-000"
@@ -212,7 +205,7 @@
                 "Dominik"
             ],
             "jobTitles": [
-                "Bis 2018: Maître d’enseignement et de recherche, Départemet de langue et de littérature allemandes, Faculté des Lettres, Université de Genève 1991-2013 Beratendes Mitglied des Herausgeberteams; seit 2016 Präsident der Stiftung für eine Historisch-Kritische Gottfried Keller-Ausgabe"
+                "Dr. phil."
             ],
             "affiliation": [
                 "http://ns.dasch.swiss/repository#dsp-083C-organization-000",

--- a/services/metadata/backend/data/incunabula.json
+++ b/services/metadata/backend/data/incunabula.json
@@ -119,8 +119,8 @@
                 {
                     "__type": "URL",
                     "type": "URL",
-                    "url": "http://data.dasch.swiss/incunabula",
-                    "text": "http://data.dasch.swiss/incunabula"
+                    "url": "https://admin.dasch.swiss/beta/project/0803",
+                    "text": "https://admin.dasch.swiss/beta/project/0803"
                 }
             ]
         }

--- a/services/metadata/backend/data/incunabula.json
+++ b/services/metadata/backend/data/incunabula.json
@@ -56,6 +56,12 @@
             "Schweizer Tobias u. Rosenthaler Lukas (2011), SALSAH - eine virtuelle Forschungsumgebung für die Geisteswissenschaften, in Bienert Andreas u.a. (ed.), GFaI, Berlin, 147-153.",
             "Schweizer Tobias, Development of a Topographical Transcription Method, in Clivaz Claire u. a. (ed.), ebook, auf der Plattform http://www.ppur.info/lire-demain.html, Lausanne, 671-680."
         ],
+        "url": {
+            "__type": "URL",
+            "type": "URL",
+            "url": "https://admin.dasch.swiss/beta/project/0803",
+            "text": "https://admin.dasch.swiss/beta/project/0803"
+        },
         "shortcode": "0803",
         "startDate": "2008-06-01"
     },
@@ -234,8 +240,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "https://p3.snf.ch/project-120378",
-                "text": "https://p3.snf.ch/project-120378"
+                "url": "https://data.snf.ch/grants/grant/120378",
+                "text": "https://data.snf.ch/grants/grant/120378"
             }
         }
     ]

--- a/services/metadata/backend/data/lenzburg.json
+++ b/services/metadata/backend/data/lenzburg.json
@@ -96,7 +96,7 @@
             "url": "https://admin.dasch.swiss/beta/project/082A",
             "text": "https://admin.dasch.swiss/beta/project/082A"
         },
-        "url": {
+        "secondaryURL": {
             "__type": "URL",
             "type": "URL",
             "url": "https://www.volkskunde.ch/sgv/archive-und-sammlungen/volksliederarchiv",

--- a/services/metadata/backend/data/lenzburg.json
+++ b/services/metadata/backend/data/lenzburg.json
@@ -93,6 +93,12 @@
         "url": {
             "__type": "URL",
             "type": "URL",
+            "url": "https://admin.dasch.swiss/beta/project/082A",
+            "text": "https://admin.dasch.swiss/beta/project/082A"
+        },
+        "url": {
+            "__type": "URL",
+            "type": "URL",
             "url": "https://www.volkskunde.ch/sgv/archive-und-sammlungen/volksliederarchiv",
             "text": "https://www.volkskunde.ch/sgv/archive-und-sammlungen/volksliederarchiv"
         }

--- a/services/metadata/backend/data/lhtt.json
+++ b/services/metadata/backend/data/lhtt.json
@@ -628,8 +628,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "https://p3.snf.ch/project-162967",
-                "text": "https://p3.snf.ch/project-162967"
+                "url": "https://data.snf.ch/grants/grant/162967",
+                "text": "https://data.snf.ch/grants/grant/162967"
             }
         }
     ]

--- a/services/metadata/backend/data/mfmps.json
+++ b/services/metadata/backend/data/mfmps.json
@@ -109,8 +109,8 @@
         "url": {
             "__type": "URL",
             "type": "URL",
-            "url": "https://admin.ls-prod-server.dasch.swiss/project/0116/info",
-            "text": "https://admin.ls-prod-server.dasch.swiss/project/0116/info"
+            "url": "https://admin.ls-prod-server.dasch.swiss/beta/project/0116",
+            "text": "https://admin.ls-prod-server.dasch.swiss/beta/project/0116"
         },
         "secondaryURL": {
             "__type": "URL",
@@ -368,8 +368,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "http://p3.snf.ch/project-179787",
-                "text": "http://p3.snf.ch/project-179787"
+                "url": "https://data.snf.ch/grants/grant/179787",
+                "text": "https://data.snf.ch/grants/grant/179787"
             }
         }
     ]

--- a/services/metadata/backend/data/mls.json
+++ b/services/metadata/backend/data/mls.json
@@ -192,7 +192,7 @@
             "url": "https://admin.dasch.swiss/beta/project/0807",
             "text": "https://admin.dasch.swiss/beta/project/0807"
         },
-        "url": {
+        "secondaryURL": {
             "__type": "URL",
             "type": "URL",
             "url": "https://mls.0807.dasch.swiss/home",
@@ -256,20 +256,6 @@
                     "agent": "http://ns.dasch.swiss/repository#dsp-0807-person-001",
                     "roles": [
                         "Responsible for the Dataset, Contact with DaSCH"
-                    ]
-                },
-                {
-                    "__type": "Attribution",
-                    "agent": "http://ns.dasch.swiss/repository#dsp-0807-organization-003",
-                    "roles": [
-                        "Patron"
-                    ]
-                },
-                {
-                    "__type": "Attribution",
-                    "agent": "http://ns.dasch.swiss/repository#dsp-0807-organization-004",
-                    "roles": [
-                        "Maintainer"
                     ]
                 },
                 {

--- a/services/metadata/backend/data/mls.json
+++ b/services/metadata/backend/data/mls.json
@@ -189,6 +189,12 @@
         "url": {
             "__type": "URL",
             "type": "URL",
+            "url": "https://admin.dasch.swiss/beta/project/0807",
+            "text": "https://admin.dasch.swiss/beta/project/0807"
+        },
+        "url": {
+            "__type": "URL",
+            "type": "URL",
             "url": "https://mls.0807.dasch.swiss/home",
             "text": "https://mls.0807.dasch.swiss/home"
         }

--- a/services/metadata/backend/data/nietzsche.json
+++ b/services/metadata/backend/data/nietzsche.json
@@ -414,8 +414,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "http://p3.snf.ch/project-198240",
-                "text": "http://p3.snf.ch/project-198240"
+                "url": "https://data.snf.ch/grants/grant/198240",
+                "text": "https://data.snf.ch/grants/grant/198240"
             }
         }
     ]

--- a/services/metadata/backend/data/olympic.json
+++ b/services/metadata/backend/data/olympic.json
@@ -84,8 +84,8 @@
         "url": {
             "__type": "URL",
             "type": "URL",
-            "url": "https://admin.ls-prod-server.dasch.swiss/project/0114/info",
-            "text": "https://admin.ls-prod-server.dasch.swiss/project/0114/info"
+            "url": "https://admin.ls-prod-server.dasch.swiss/beta/project/0114",
+            "text": "https://admin.ls-prod-server.dasch.swiss/beta/project/0114"
         },
         "secondaryURL": {
             "__type": "URL",
@@ -383,8 +383,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "http://p3.snf.ch/project-179043",
-                "text": "http://p3.snf.ch/project-179043"
+                "url": "https://data.snf.ch/grants/grant/179043",
+                "text": "https://data.snf.ch/grants/grant/179043"
             }
         }
     ]

--- a/services/metadata/backend/data/reforme-geneve.json
+++ b/services/metadata/backend/data/reforme-geneve.json
@@ -94,8 +94,8 @@
         "url": {
             "__type": "URL",
             "type": "URL",
-            "url": "https://admin.ls-prod-server.dasch.swiss/project/0111/info",
-            "text": "https://admin.ls-prod-server.dasch.swiss/project/0111/info"
+            "url": "https://admin.ls-prod-server.dasch.swiss/beta/project/0111",
+            "text": "https://admin.ls-prod-server.dasch.swiss/beta/project/0111"
         },
         "secondaryURL": {
             "__type": "URL",

--- a/services/metadata/backend/data/religious-speech.json
+++ b/services/metadata/backend/data/religious-speech.json
@@ -103,8 +103,8 @@
         "url": {
             "__type": "URL",
             "type": "URL",
-            "url": "https://admin.ls-prod-server.dasch.swiss/project/0101/info",
-            "text": "https://admin.ls-prod-server.dasch.swiss/project/0101/info"
+            "url": "https://admin.ls-prod-server.dasch.swiss/beta/project/0101",
+            "text": "https://admin.ls-prod-server.dasch.swiss/beta/project/0101"
         },
         "secondaryURL": {
             "__type": "URL",
@@ -451,8 +451,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "http://p3.snf.ch/Project-165652",
-                "text": "http://p3.snf.ch/Project-165652"
+                "url": "https://data.snf.ch/grants/grant/165652",
+                "text": "https://data.snf.ch/grants/grant/165652"
             }
         }
     ]

--- a/services/metadata/backend/data/roud.json
+++ b/services/metadata/backend/data/roud.json
@@ -97,8 +97,8 @@
         "url": {
             "__type": "URL",
             "type": "URL",
-            "url": "https://admin.ls-prod-server.dasch.swiss/project/0112/info",
-            "text": "https://admin.ls-prod-server.dasch.swiss/project/0112/info"
+            "url": "https://admin.ls-prod-server.dasch.swiss/beta/project/0112",
+            "text": "https://admin.ls-prod-server.dasch.swiss/beta/project/0112"
         },
         "secondaryURL": {
             "__type": "URL",
@@ -498,8 +498,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "http://p3.snf.ch/Project-157970",
-                "text": "http://p3.snf.ch/Project-157970"
+                "url": "https://data.snf.ch/grants/grant/157970",
+                "text": "https://data.snf.ch/grants/grant/157970"
             }
         }
     ]

--- a/services/metadata/backend/data/stardom.json
+++ b/services/metadata/backend/data/stardom.json
@@ -95,8 +95,8 @@
         "url": {
             "__type": "URL",
             "type": "URL",
-            "url": "https://admin.ls-prod-server.dasch.swiss/project/0107/info",
-            "text": "https://admin.ls-prod-server.dasch.swiss/project/0107/info"
+            "url": "https://admin.ls-prod-server.dasch.swiss/beta/project/0107",
+            "text": "https://admin.ls-prod-server.dasch.swiss/beta/project/0107"
         },
         "secondaryURL": {
             "__type": "URL",
@@ -427,8 +427,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "http://p3.snf.ch/Project-166366",
-                "text": "http://p3.snf.ch/Project-166366"
+                "url": "https://data.snf.ch/grants/grant/166366",
+                "text": "https://data.snf.ch/grants/grant/166366"
             }
         }
     ]

--- a/services/metadata/backend/data/tdk.json
+++ b/services/metadata/backend/data/tdk.json
@@ -251,8 +251,8 @@
             "funders": [
                 "http://ns.dasch.swiss/repository#dsp-0805-organization-001"
             ],
-            "name": "SNF Project",
-            "number": "SNF 100011_156046",
+            "name": "Project funding",
+            "number": "156046",
             "url": {
                 "__type": "URL",
                 "type": "URL",

--- a/services/metadata/backend/data/tdk.json
+++ b/services/metadata/backend/data/tdk.json
@@ -256,8 +256,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "http://p3.snf.ch/project-156046",
-                "text": "http://p3.snf.ch/project-156046"
+                "url": "https://data.snf.ch/grants/grant/156046",
+                "text": "https://data.snf.ch/grants/grant/156046    "
             }
         }
     ]

--- a/services/metadata/backend/data/tds.json
+++ b/services/metadata/backend/data/tds.json
@@ -162,8 +162,8 @@
         "url": {
             "__type": "URL",
             "type": "URL",
-            "url": "http://theatresdesociete.unil.ch/",
-            "text": "http://theatresdesociete.unil.ch/"
+            "url": "https://admin.ls-prod-server.dasch.swiss/beta/project/0103",
+            "text": "https://admin.ls-prod-server.dasch.swiss/beta/project/0103"
         },
         "secondaryURL": {
             "__type": "URL",
@@ -536,8 +536,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "http://p3.snf.ch/Project-157392",
-                "text": "http://p3.snf.ch/Project-157392"
+                "url": "https://data.snf.ch/grants/grant/157392",
+                "text": "https://data.snf.ch/grants/grant/157392"
             }
         },
         {
@@ -553,8 +553,8 @@
             "url": {
                 "__type": "URL",
                 "type": "URL",
-                "url": "http://p3.snf.ch/Project-190070",
-                "text": "http://p3.snf.ch/Project-190070"
+                "url": "https://data.snf.ch/grants/grant/190070",
+                "text": "https://data.snf.ch/grants/grant/190070"
             }
         }
     ]


### PR DESCRIPTION
Add 2 new projects (Rome obscure, eHKKA)
Change all project website links to Beta Preview Links
Replace all the p3 links with the new links on the new grant search from the SNFS
Remove the following Links (Manser, Delille)

Minor corrections:
- rome obscure - fix vocab.getty
- eHKKA - fix jobtitles and remove creator of dataset as attribution
- fix secondaryURL in several projects
- drawings of gods - add beta project view
- mls - fix attributions
- incunabula - replace data.dasch.swiss with beta project view
- tdk - fix grant name