### PR TITLE
chore: fix excluded Fathom Analytics domains

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
       src="https://cdn.usefathom.com/script.js"
       data-spa="history"
       data-site="FGMNMBLN"
-      data-excluded-domains="localhost,meta.test.dasch.swiss,meta.staging.dasch.swiss"
+      data-excluded-domains="localhost,meta.test.dasch.swiss,meta.stage.dasch.swiss"
       defer>
     </script>
   </head>


### PR DESCRIPTION
Not sure if we will need it, but spotted it in new repo, so to align changing it here too.